### PR TITLE
Update conferences.md

### DIFF
--- a/conferences.md
+++ b/conferences.md
@@ -4,6 +4,22 @@
 
 A list of virtual conferences to learn about cool economics things without having to jump into a seething mass of plague vectors.
 
+### Canadian Economic Theory Conference 2020
+
+The yearly economic theory conference scheduled for May 8-10 in Vancouver is online this year.  The submission deadline has passed, but the program should be available around April 10.  This will be a Zoom conference.  
+
+The organizing committee:
+
+1. [Michael Peters](https://montoya.econ.ubc.ca)
+1. [Sergei Severinov](https://economics.ubc.ca/faculty-and-staff/sergei-severinov/)
+1. [Li Hao](https://faculty.arts.ubc.ca/lhao/)
+1. [Li Wei](https://economics.ubc.ca/faculty-and-staff/wei-li/)
+1. [Vitor Fahrina Luz](https://economics.ubc.ca/faculty-and-staff/vitor-farinha-luz/)
+1. [Shunya Noda](https://economics.ubc.ca/faculty-and-staff/shunya-noda/)
+
+[Conference Webpage](https://www.economics.utoronto.ca/conferences/index.php/cetc/2020)
+
+
 ### Virtual Finance & Economics Conference 2020
 
 A fully remote conference for researchers in economics and finance. Contributions that highlight our changing times are welcomed. 


### PR DESCRIPTION
Adding canadian economic theory conference for 2020